### PR TITLE
#8 added addDataSources convenience method

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -6,6 +6,7 @@
   "type":"module",
   "scripts": {
     "szconfig/addDataSource.ts": "tsx szconfig/addDataSource.ts",
+    "szconfig/addDataSources.ts": "tsx szconfig/addDataSources.ts",
     "szconfig/constructor.ts": "tsx szconfig/constructor.ts",
     "szconfig/createAndClose.ts": "tsx szconfig/createAndClose.ts",
     "szconfig/createExportImportClose.ts": "tsx szconfig/createExportImportClose.ts",

--- a/examples/szconfig/addDataSources.ts
+++ b/examples/szconfig/addDataSources.ts
@@ -1,0 +1,17 @@
+import { SzGrpcEnvironment } from '@senzing/sz-sdk-typescript-grpc';
+
+const szEnvironment         = new SzGrpcEnvironment({connectionString: `0.0.0.0:8261`});
+const DATASOURCES_TO_ADD    = ['CUSTOMERS', 'REFERENCE', 'WATCHLIST'];
+
+// create new config and get handle
+szEnvironment.getConfig().createConfig().then((configHandle) => {
+    // now add datasources
+    szEnvironment.getConfig().addDataSources(configHandle as number, DATASOURCES_TO_ADD).then((results) => {
+        console.log(`Added Data Sources: \n\r`, results);
+    }).
+    catch((err) => {
+        console.error(err);
+    });
+}).catch((err) => {
+    console.error(err);
+})


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #8 

## Why was change needed

Calling `SzGrpcConfig.addDataSource` multiple times asyncronously results in `Connection Dropped` error. I had a hunch that it had something to do with the nature of non-threaded async requests over the grpc client. (I was right)

Normally you would use a [Generator Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) along with `await` and `async` but google has made this all but impossible by requiring using the *CommonJS* or *Closure* module style instead of the newer defacto standard [ESM](https://nodejs.org/api/esm.html). Until google updates their protoc compiler plugins to use ESM our hands are kind of tied on this.

Creating promises one after the previous is at best tedious and at worst mind-boggling depending on how familiar a developer is with node/js. I decided to write a helper function with internal subs(basically a class masquerading as a function) that handles the wackyness of doing sequential promises. This is preferable over asking the user to work around the limitations of node/promises in a snippet/example.

## What does change improve

Ability to call `SzConfig.addDataSources(configHandle, ['DS1','DS2','DS3'])` in one line instead of 50 lines of example code.
