### PR TITLE
Fix getVirtualEntityByRecordId double JSON encoding

### DIFF
--- a/src/szGrpcEngine.ts
+++ b/src/szGrpcEngine.ts
@@ -824,7 +824,7 @@ export class SzGrpcEngine extends SzGrpcBase implements SzEngine {
                     return;
                 }
                 const request = new GetVirtualEntityByRecordIdRequest();
-                request.setRecordKeys(JSON.stringify( recordIdsAsJsonString(recordKeys) ));
+                request.setRecordKeys(recordIdsAsJsonString(recordKeys));
                 request.setFlags(bigIntToNumber(flags));
                 this.client.getVirtualEntityByRecordId(request, this._metadata, (err, res: GetVirtualEntityByRecordIdResponse)=>{
                     if(err) {

--- a/src/szGrpcWebEngine.ts
+++ b/src/szGrpcWebEngine.ts
@@ -824,7 +824,7 @@ export class SzGrpcWebEngine extends SzGrpcWebBase implements SzEngine {
                     return;
                 }
                 const request = new GetVirtualEntityByRecordIdRequest();
-                request.setRecordKeys(JSON.stringify( recordIdsAsJsonString(recordKeys) ));
+                request.setRecordKeys(recordIdsAsJsonString(recordKeys));
                 request.setFlags(bigIntToNumber(flags));
                 this.client.getVirtualEntityByRecordId(request, this._metadata, (err, res: GetVirtualEntityByRecordIdResponse)=>{
                     if(err) {

--- a/src/szHelpers.ts
+++ b/src/szHelpers.ts
@@ -153,7 +153,7 @@ export function recordIdsAsJsonString(values: Array<[string, string | number]>):
     let retVal = "";
     if(Array.isArray(values)) {
         let identifiersList = (values as Array<[string, string | number]>).map((recordKey: [string, string | number]) => {
-            return `{"DATA_SOURCE": "${recordKey[0]}", "RECORD_ID": "${recordKey[1]}"})`;
+            return `{"DATA_SOURCE": "${recordKey[0]}", "RECORD_ID": "${recordKey[1]}"}`;
         });
         retVal = `{"RECORDS": [${identifiersList.join(',')}]}`;
     }


### PR DESCRIPTION
## Summary

- Remove extra `)` from JSON template in `recordIdsAsJsonString()` in szHelpers.ts
- Remove unnecessary `JSON.stringify()` wrapper in `getVirtualEntityByRecordId()` for both szGrpcEngine and szGrpcWebEngine

## Problem

The `getVirtualEntityByRecordId` method was double-encoding the JSON payload:

1. `recordIdsAsJsonString()` returns a JSON string like `{"RECORDS": [...]}`
2. This was then wrapped in `JSON.stringify()`, producing `"{\"RECORDS\": [...]}"` 

The Java gRPC server then received a JSON string value instead of a JSON object, causing:
```
JsonParsingException: JsonParser#getObject() or JsonParser#getObjectStream() is valid only for START_OBJECT parser state. But current parser state is VALUE_STRING
```

Additionally, there was a typo in `recordIdsAsJsonString()` that added an extra `)` after each record object.

## Test plan

- [x] Build succeeds with `npm run build`
- [ ] Test with How Report functionality in eval-tool-app-web

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)