### PR TITLE
Add typeRoots to tsconfig.web.json for submodule compatibility

### DIFF
--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -14,7 +14,8 @@
     "removeComments": false,
     "sourceMap": true,
     "declaration": true,
-    "noEmitOnError": true
+    "noEmitOnError": true,
+    "typeRoots": ["./node_modules/@types"]
   },
   "files": [
     "src/szGrpcWebConfig.ts",


### PR DESCRIPTION
## Summary
- When this repo is used as a git submodule, TypeScript's default type resolution walks up the directory tree and picks up `@types` from the parent project (d3, jasmine, jest, etc.), causing hundreds of type conflicts during `npm run build:web`.
- Adding `typeRoots: ["./node_modules/@types"]` constrains type resolution to the repo's own `node_modules`, fixing the build when used as a submodule while having no effect on standalone builds.

## Test plan
- [ ] `npm run build:web` succeeds standalone (no regression)
- [ ] `npm run build:web` succeeds when repo is checked out as a submodule inside another project with conflicting `@types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)