### PR TITLE
Convert protobuf CJS exports to ESM named exports

### DIFF
--- a/build.web.js
+++ b/build.web.js
@@ -88,6 +88,9 @@ for (const file of pbFiles) {
             /goog\.object\.extend\(exports, proto\.\w+\);/,
             namedExports
         );
+    } else {
+        console.warn('WARNING: Could not convert CJS exports to ESM in:', file,
+            `(extendsMatch: ${!!extendsMatch}, symbols: ${symbols.length})`);
     }
 
     fs.writeFileSync(file, content, 'utf8');


### PR DESCRIPTION
## Summary

- Protobuf-generated `_web_pb.js` files use `goog.object.extend(exports, proto.xxx)` (CJS pattern) which is undefined in ESM mode, causing all imports from these files to be `undefined` at runtime
- Updated `build.web.js` to parse `goog.exportSymbol()` declarations and replace the CJS `exports` line with individual ESM `export const` statements
- Replaced async `replaceInFile` with synchronous `fs.readFileSync`/`writeFileSync` so both the `require→import` and `exports→export` conversions complete before the build script exits

Follows up on #121 which added `"type": "module"` to the web package.

## Test plan

- [ ] `npm run build:web` succeeds and shows conversion output for all 5 `_web_pb.js` files
- [ ] Verify dist `_web_pb.js` files end with `export const` statements instead of `goog.object.extend(exports, ...)`
- [ ] Angular app build (`ng build`) shows no `import-is-undefined` warnings
- [ ] gRPC web calls work at runtime (search, entity detail, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Resolves #121