### PR TITLE
Add .js extensions to ESM imports for Node.js compatibility

### DIFF
--- a/build.web.js
+++ b/build.web.js
@@ -57,8 +57,34 @@ fs.cpSync(path.join('.','src'), path.join('.', ...'dist/@senzing/sz-sdk-typescri
     }
 });
 
-// convert CJS patterns in _web_pb.js files to ESM
+// add .js extensions to relative imports in all .js files (Node.js ESM requires explicit extensions)
 const distDir = path.join('.', ...'dist/@senzing/sz-sdk-typescript-grpc-web'.split('/'));
+const allJsFiles = glob.sync(path.join(distDir, '**/*.js'));
+for (const file of allJsFiles) {
+    const fileDir = path.dirname(file);
+    let content = fs.readFileSync(file, 'utf8');
+    let changed = false;
+    // match: from "./path" or from "../path" (without .js extension)
+    const updated = content.replace(
+        /(from\s+["'])(\.\.?\/[^"']+)(["'])/g,
+        (match, pre, importPath, post) => {
+            if (importPath.endsWith('.js') || importPath.endsWith('.json')) return match;
+            const resolved = path.resolve(fileDir, importPath);
+            // check if it's a directory (resolve to /index.js)
+            if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+                changed = true;
+                return `${pre}${importPath}/index.js${post}`;
+            }
+            changed = true;
+            return `${pre}${importPath}.js${post}`;
+        }
+    );
+    if (changed) {
+        fs.writeFileSync(file, updated, 'utf8');
+    }
+}
+
+// convert CJS patterns in _web_pb.js files to ESM
 const pbFiles = glob.sync(path.join(distDir, '**/*_web_pb.js'));
 for (const file of pbFiles) {
     let content = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
## Summary

- TypeScript emits extensionless relative imports (`from "./foo"`) which bundlers handle but Node.js ESM requires explicit `.js` extensions
- Without this fix, `require('@senzing/sz-sdk-typescript-grpc-web')` fails in Node.js with `ERR_MODULE_NOT_FOUND` because the package has `"type": "module"`
- The build script now post-processes all `.js` files to append `.js` to relative imports, resolving directory imports to `/index.js`

Follows up on #121 and #122 to complete the ESM migration.

## Test plan

- [ ] `npm run build:web` succeeds
- [ ] `node -e "require('@senzing/sz-sdk-typescript-grpc-web')"` works without `ERR_MODULE_NOT_FOUND`
- [ ] Docker container using this package starts without module resolution errors
- [ ] Angular app build has no `import-is-undefined` or `Could not resolve` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Resolves #121
Resolves #122